### PR TITLE
Fix open_console at instances

### DIFF
--- a/instances/templates/instances.html
+++ b/instances/templates/instances.html
@@ -203,7 +203,7 @@
                                                                 <button class="btn btn-sm btn-default" type="submit" name="powercycle" title="{% trans "Power Cycle" %}" onclick="return confirm('Are you sure?')">
                                                                     <span class="glyphicon glyphicon-refresh"></span>
                                                                 </button>
-                                                                <a href="#" class="btn btn-sm btn-default" onclick='open_console("{{ host.0 }}-{{ vm.uuid }}")' title="{% trans "Console" %}">
+                                                                <a href="#" class="btn btn-sm btn-default" onclick='open_console("{{ vm.compute_id }}-{{ vm.uuid }}")' title="{% trans "Console" %}">
                                                                     <span class="glyphicon glyphicon-eye-open"></span>
                                                                 </a>
                                                             {% endifequal %}


### PR DESCRIPTION
When user (not superuser) opens `Console` at instances, 500 error occured.
So, I fixed `onclick` of `Console` link.