### PR TITLE
Create instances with a random generated vnc password by default

### DIFF
--- a/instances/views.py
+++ b/instances/views.py
@@ -15,6 +15,7 @@ from accounts.models import UserInstance, UserSSHKey
 from vrtManager.hostdetails import wvmHostDetails
 from vrtManager.instance import wvmInstance, wvmInstances
 from vrtManager.connection import connection_manager
+from vrtManager.util import randomPasswd
 from libvirt import libvirtError, VIR_DOMAIN_XML_SECURE
 from webvirtcloud.settings import QEMU_KEYMAPS, QEMU_CONSOLE_TYPES
 from logs.views import addlogmsg
@@ -419,7 +420,7 @@ def instance(request, compute_id, vname):
 
                 if 'set_console_passwd' in request.POST:
                     if request.POST.get('auto_pass', ''):
-                        passwd = ''.join([choice(letters + digits) for i in xrange(12)])
+                        passwd = randomPasswd()
                     else:
                         passwd = request.POST.get('console_passwd', '')
                         clear = request.POST.get('clear_pass', False)

--- a/vrtManager/create.py
+++ b/vrtManager/create.py
@@ -227,7 +227,7 @@ class wvmCreate(wvmConnect):
 
         xml += """  <input type='mouse' bus='ps2'/>
                     <input type='tablet' bus='usb'/>
-                    <graphics type='%s' port='-1' autoport='yes' listen='0.0.0.0'>
+                    <graphics type='%s' port='-1' autoport='yes' listen='0.0.0.0' passwd='%s'>
                       <listen type='address' address='0.0.0.0'/>
                     </graphics>
                     <console type='pty'/>
@@ -236,5 +236,5 @@ class wvmCreate(wvmConnect):
                     </video>
                     <memballoon model='virtio'/>
                   </devices>
-                </domain>""" % QEMU_CONSOLE_DEFAULT_TYPE
+                </domain>""" % (QEMU_CONSOLE_DEFAULT_TYPE, util.randomPasswd())
         self._defineXML(xml)

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -1,6 +1,7 @@
 import random
 import libxml2
 import libvirt
+import string
 
 
 def is_kvm_available(xml):
@@ -27,6 +28,11 @@ def randomUUID():
 
     u = [random.randint(0, 255) for dummy in range(0, 16)]
     return "-".join(["%02x" * 4, "%02x" * 2, "%02x" * 2, "%02x" * 2, "%02x" * 6]) % tuple(u)
+
+
+def randomPasswd(length=12, alphabet=string.letters + string.digits):
+    """Generate a random password"""
+    return ''.join([random.choice(alphabet) for i in xrange(length)])
 
 
 def get_max_vcpus(conn, type=None):


### PR DESCRIPTION
Instead of creating instance with no password, created them with a generated password. The password is readable in vncsettings.

This is another  way to fix #95