### PR TITLE
Fixing add storage regex issue on 'iso path' and 'lvm name'

### DIFF
--- a/storages/templates/create_stg_block.html
+++ b/storages/templates/create_stg_block.html
@@ -66,7 +66,7 @@
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label">{% trans "Name" %}</label>
                                     <div class="col-sm-6">
-                                        <input type="text" class="form-control" name="name" placeholder="default" maxlength="20" required pattern="[a-zA-Z0-9\.\-\_]+">
+                                        <input type="text" class="form-control" name="name" placeholder="default" maxlength="20" required pattern="[a-zA-Z0-9\.\-_]+">
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -217,7 +217,7 @@
                                 <div class="form-group">
                                     <label class="col-sm-3 control-label">{% trans "Path" %}</label>
                                     <div class="col-sm-6">
-                                        <input type="text" class="form-control" name="target" value="/var/www/webvirtmgr/images" required pattern="[a-zA-Z0-9\/\-\_]+">
+                                        <input type="text" class="form-control" name="target" value="/var/www/webvirtmgr/images" required pattern="[a-zA-Z0-9\/\-_]+">
                                     </div>
                                 </div>
                         </div>


### PR DESCRIPTION
Javascript is complaining about the escaped underscore in the form input required pattern. A console error occurs in both chrome and firefox. Chrome seems to not allow the input at all. Seen on OSX.
Fixing for "iso path" and "lvm name".  