### PR TITLE
fix:sorted btween 'dict' and 'dict'

### DIFF
--- a/instances/views.py
+++ b/instances/views.py
@@ -330,7 +330,7 @@ def instance(request, compute_id, vname):
         console_type = conn.get_console_type()
         console_port = conn.get_console_port()
         console_keymap = conn.get_console_keymap()
-        snapshots = sorted(conn.get_snapshot(), reverse=True)
+        snapshots = sorted(conn.get_snapshot(), reverse=True, key=lambda k:k['date'])
         inst_xml = conn._XMLDesc(VIR_DOMAIN_XML_SECURE)
         has_managed_save_image = conn.get_managed_save_image()
         clone_disks = show_clone_disk(disks, vname)
@@ -955,7 +955,7 @@ def delete_instance(instance, delete_disk=False):
             print("Forcing shutdown")
             conn.force_shutdown()
         if delete_disk:
-            snapshots = sorted(conn.get_snapshot(), reverse=True)
+            snapshots = sorted(conn.get_snapshot(), reverse=True, key=lambda k:k['date'])
             for snap in snapshots:
                 print("Deleting snapshot {}".format(snap['name']))
                 conn.snapshot_delete(snap['name'])


### PR DESCRIPTION
in the function `get_snapshot`，it return a list of dict, such as:
```
[
    {'date':'', 'name': ''},
    {'date':'', 'name': ''},
]
```
it raise an Exception `sorted` not supported between instances of 'dict' and 'dict'.