### PR TITLE
Some improvements for appsettings app

### DIFF
--- a/appsettings/admin.py
+++ b/appsettings/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/appsettings/context_processors.py
+++ b/appsettings/context_processors.py
@@ -1,0 +1,13 @@
+from .settings import app_settings as settings
+
+
+def app_settings(request):
+    """
+    Simple context processor that puts the config into every\
+    RequestContext. Just make sure you have a setting like this::
+        TEMPLATE_CONTEXT_PROCESSORS = (
+            # ...
+            'appsettings.context_processors.app_settings',
+        )
+    """
+    return {"app_settings": settings}

--- a/appsettings/middleware.py
+++ b/appsettings/middleware.py
@@ -1,0 +1,10 @@
+from .settings import app_settings, get_settings
+
+
+class AppSettingsMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        get_settings()
+        return self.get_response(request)

--- a/appsettings/settings.py
+++ b/appsettings/settings.py
@@ -1,0 +1,18 @@
+from .models import AppSettings
+
+
+class Settings(object):
+    pass
+
+
+app_settings = Settings()
+
+
+def get_settings():
+    try:
+        entries = AppSettings.objects.all()
+    except:
+        pass
+
+    for entry in entries:
+        setattr(app_settings, entry.key, entry.val)

--- a/appsettings/settings.py
+++ b/appsettings/settings.py
@@ -15,4 +15,4 @@ def get_settings():
         pass
 
     for entry in entries:
-        setattr(app_settings, entry.key, entry.val)
+        setattr(app_settings, entry.key, entry.value)

--- a/instances/templates/instance.html
+++ b/instances/templates/instance.html
@@ -1704,7 +1704,7 @@
         </div>
     </div>
 
-    {% if bottom_bar %}
+    {% if app_settings.VIEW_INSTANCE_DETAIL_BOTTOM_BAR == 'True' %}
         {% include 'bottom_bar.html' %}
     {% endif %}
 

--- a/webvirtcloud/settings.py.template
+++ b/webvirtcloud/settings.py.template
@@ -50,6 +50,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.RemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'appsettings.middleware.AppSettingsMiddleware',
 ]
 
 ROOT_URLCONF = 'webvirtcloud.urls'
@@ -67,6 +68,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'appsettings.context_processors.app_settings',
             ],
             'libraries': {
                 'common_tags': 'webvirtcloud.common_tags',


### PR DESCRIPTION
Note that settings.py now require `'appsettings.middleware.AppSettingsMiddleware',` and `'appsettings.context_processors.app_settings',` in `MIDDLEWARE` and `context_processors` respectively.