### PR TITLE
Fix Port configuration for novncd

### DIFF
--- a/console/novncd
+++ b/console/novncd
@@ -18,7 +18,7 @@ django.setup()
 import re
 import socket
 from six.moves import http_cookies as Cookie
-from webvirtcloud.settings import WS_PUBLIC_PORT, WS_HOST, WS_CERT
+from webvirtcloud.settings import WS_PORT, WS_HOST, WS_CERT
 from vrtManager.connection import CONN_SSH, CONN_SOCKET
 from console.sshtunnels import SSHTunnels
 from optparse import OptionParser
@@ -51,7 +51,7 @@ parser.add_option("-p",
                   dest="port",
                   action="store",
                   help="Listen port",
-                  default=WS_PUBLIC_PORT or 6080)
+                  default=WS_PORT or 6080)
 
 parser.add_option("-c",
                   "--cert",


### PR DESCRIPTION
Revert accidentally change variable for novncd port configuration.

Change variable `WS_PUBLIC_PORT` back to `WS_PORT`