### PR TITLE
Downgrade libvirt-python to fix taking snapshots

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -8,7 +8,7 @@ django-qr-code==1.3.1
 gunicorn==20.0.4
 importlib-metadata==1.7.0
 libsass==0.20.1
-libvirt-python==6.8.0
+libvirt-python==6.7.0
 lxml==4.5.2
 numpy==1.19.2
 pytz==2020.1


### PR DESCRIPTION
Looks like libvirt-python 6.8.0 has some weird bug which causes `NameError: name 'dom' is not defined` on trying to snapshot instance. Downgrading to 6.7.0 fixes the issue.