### PR TITLE
script fixes etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 How to update <code>gstfsd</code> daemon on hypervisor:
 
 ```bash
-wget -O - https://clck.ru/9VMRH | sudo tee -a /usr/local/bin/gstfsd
+wget -O - https://bit.ly/2NAaWXG | sudo tee -a /usr/local/bin/gstfsd
 sudo service supervisor restart
 ```
 
@@ -86,7 +86,7 @@ sudo service supervisor restart
 Setup libvirt and KVM on server
 
 ```bash
-wget -O - https://clck.ru/9V9fH | sudo sh
+wget -O - https://bit.ly/36baWUu | sudo sh
 ```
 
 Done!!

--- a/conf/supervisor/gstfsd.conf
+++ b/conf/supervisor/gstfsd.conf
@@ -1,5 +1,5 @@
 [program:gstfsd]
-command=/srv/webvirtcloud/venv/bin/python3 /usr/local/bin/gstfsd
+command=/usr/bin/python3 /usr/local/bin/gstfsd
 directory=/usr/local/bin
 user=root
 autostart=true

--- a/instances/views.py
+++ b/instances/views.py
@@ -769,7 +769,7 @@ def revert_snapshot(request, pk):
         msg = _("Successful revert snapshot: ")
         msg += snap_name
         messages.success(request, msg)
-        msg = _("Revert snapshot: %(snap)") % {"snap": snap_name}
+        msg = _("Revert snapshot: %(snap)s") % {"snap": snap_name}
         addlogmsg(request.user.username, instance.name, msg)
     return redirect(request.META.get("HTTP_REFERER") + "#managesnapshot")
 
@@ -887,7 +887,7 @@ def set_video_model(request, pk):
     instance = get_instance(request.user, pk)
     video_model = request.POST.get("video_model", "vga")
     instance.proxy.set_video_model(video_model)
-    msg = _("Set Video Model: %(model)") % {"model": video_model}
+    msg = _("Set Video Model: %(model)s") % {"model": video_model}
     addlogmsg(request.user.username, instance.name, msg)
     return redirect(request.META.get("HTTP_REFERER") + "#options")
 

--- a/webvirtcloud.sh
+++ b/webvirtcloud.sh
@@ -455,7 +455,7 @@ case $distro in
     log "yum -y install wget epel-release"
 
     echo "* Installing OS requirements."
-    PACKAGES="git python3-virtualenv python3-devel libvirt-devel glibc gcc nginx supervisor python3-lxml python3-libguestfs iproute-tc cyrus-sasl-md5 python3-libguestfs"
+    PACKAGES="git python3-virtualenv python3-devel libvirt-devel glibc gcc nginx supervisor python3-lxml python3-libguestfs iproute-tc cyrus-sasl-md5"
     install_packages
 
     set_hosts


### PR DESCRIPTION
Centos 8 host bootstrap script fixed. 
there is no more --listen parameter but only libvirtd-tcp or libvirtd-tls services exist for running daemon mode.
clck.ru -> bit.ly conversion is made, because wget/curl does not accept theirs algorithm and halts.

snapshot related some small bugs are fixed