### PR TITLE
Get MAC OUI from settings.py

### DIFF
--- a/instances/utils.py
+++ b/instances/utils.py
@@ -196,7 +196,7 @@ def get_dhcp_mac_address(vname):
 
 
 def get_random_mac_address():
-    mac = "52:54:00:%02x:%02x:%02x" % (
+    mac = settings.MAC_OUI + ":%02x:%02x:%02x" % (
         random.randint(0x00, 0xFF),
         random.randint(0x00, 0xFF),
         random.randint(0x00, 0xFF),

--- a/vrtManager/util.py
+++ b/vrtManager/util.py
@@ -6,6 +6,8 @@ import string
 import libvirt
 import lxml.etree as etree
 
+from django.conf import UserSettingsHolder, settings
+
 
 def is_kvm_available(xml):
     kvm_domains = get_xml_path(xml, "//domain/@type='kvm'")
@@ -15,10 +17,12 @@ def is_kvm_available(xml):
 def randomMAC():
     """Generate a random MAC address."""
     # qemu MAC
-    oui = [0x52, 0x54, 0x00]
-
-    mac = oui + [random.randint(0x00, 0xFF), random.randint(0x00, 0xFF), random.randint(0x00, 0xFF)]
-    return ":".join(map(lambda x: "%02x" % x, mac))
+    mac = settings.MAC_OUI + ":%02x:%02x:%02x" % (
+        random.randint(0x00, 0xFF),
+        random.randint(0x00, 0xFF),
+        random.randint(0x00, 0xFF),
+    )
+    return mac
 
 
 def randomUUID():

--- a/webvirtcloud/settings.py.template
+++ b/webvirtcloud/settings.py.template
@@ -15,6 +15,8 @@ SECRET_KEY = ""
 
 DEBUG = False
 
+MAC_OUI = '52:54:10'
+
 ALLOWED_HOSTS = ["*"]
 
 CSRF_TRUSTED_ORIGINS = ['http://localhost',]


### PR DESCRIPTION
Removed the hard coded MAC OUI in the code and instead fetches the OUI from settings.py

If independent instances of WebVirtCloud (or any libvirt) exists on the same subnet and VMs are configured to use a bridge interface, this could lead to duplicate MACs on the same subnet (low probability, but still possible).
This change gives the user a choice to define an OUI.

