### PR TITLE
Fixed nginx X-Forwarded-Proto to match the scheme ("http", "https")

### DIFF
--- a/conf/nginx/webvirtcloud.conf
+++ b/conf/nginx/webvirtcloud.conf
@@ -14,7 +14,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
         proxy_set_header Host $host:$server_port;
-        proxy_set_header X-Forwarded-Proto $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Ssl off;
         proxy_connect_timeout 1800;
         proxy_read_timeout 1800;


### PR DESCRIPTION
According to the specification of [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), the value shall match the used protocol (e.g., "http", "https") which is provided as scheme variable in nginx.