### PR TITLE
Fixes Quick Install overrides nginx upstream wssocketiod

### DIFF
--- a/webvirtcloud.sh
+++ b/webvirtcloud.sh
@@ -174,7 +174,7 @@ configure_nginx () {
   fi
 
   novncd_port_escape="$(echo -n "$novncd_port"|sed -e 's/[](){}<>=:\!\?\+\|\/\&$*.^[]/\\&/g')"
-  sed -i "s|\\(server 127.0.0.1:\\).*|\\1$novncd_port_escape;|" "$nginxfile"
+  sed -i "s|server 127.0.0.1:6080;|server 127.0.0.1:$novncd_port_escape;|" "$nginxfile"
 
 }
 


### PR DESCRIPTION
This (simple) patch fixes issue#614 where the Quick Install script overrides nginx upstream wssocketiod port.