### PR TITLE
crypt-r replaces crypt stdlib, support python-3.13

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -24,3 +24,4 @@ tzdata
 websockify==0.12.0
 whitenoise==6.9.0
 zipp==3.21.0
+crypt-r==3.13.1

--- a/instances/views.py
+++ b/instances/views.py
@@ -1,4 +1,4 @@
-import crypt
+import crypt_r
 import json
 import os
 import re
@@ -476,7 +476,7 @@ def set_root_pass(request, pk):
     if request.method == "POST":
         passwd = request.POST.get("passwd", None)
         if passwd:
-            passwd_hash = crypt.crypt(passwd, "$6$kgPoiREy")
+            passwd_hash = crypt_r.crypt(passwd, "$6$kgPoiREy")
             data = {"action": "password", "passwd": passwd_hash, "vname": instance.name}
 
             if instance.proxy.get_status() == 5:


### PR DESCRIPTION
The old code could not run on Python-3.13 because crypt stdlib was dropped. I try to use crypt-r to replace it and works on Python-3.13 in Debian trixie/sid. So I commit the changes and open a pull request. Hope it will be merged. Thanks. 