### PR TITLE
ubdate base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.1
+FROM phusion/baseimage:noble-1.0.2
 
 EXPOSE 80
 EXPOSE 6080


### PR DESCRIPTION
updated base image from jammy to noble due to error message during docker build

ERROR: No matching distribution found for crypt-r==3.13.1